### PR TITLE
Fix issue 10 update existing pivot isn't working

### DIFF
--- a/src/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Relations/Concerns/InteractsWithPivotTable.php
@@ -194,10 +194,11 @@ trait InteractsWithPivotTable
     protected function getCurrentlyAttachedPivots()
     {
         return $this->newPivotQueryWithoutTrashed()->get()->map(function ($record) {
-            $class = $this->using ? $this->using : Pivot::class;
+            $class = $this->using ?: Pivot::class;
 
-            return (new $class)->setRawAttributes((array) $record, true);
-        });
+            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
+
+            return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);        });
     }
 
     /**

--- a/src/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Relations/Concerns/InteractsWithPivotTable.php
@@ -198,7 +198,8 @@ trait InteractsWithPivotTable
 
             $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
 
-            return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);        });
+            return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
+        });
     }
 
     /**


### PR DESCRIPTION
Fix for #10 

Merge changes from the original InteractsWithPivotTable.php from Laravel where they updated the getCurrentlyAttachedPivots() method. See commit 5558a11 and issue 29734 in laravel/framework

https://github.com/laravel/framework/commit/5558a114cec2ebb1050ac79ba71f3eb87789ad37#diff-5603d4d15ca47b196de2c3f2c70590b20cb523a393228fc7f294a2c6a54c443c
https://github.com/laravel/framework/pull/29734